### PR TITLE
Fixing Windows Python2 compatibility

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -281,7 +281,7 @@ def make_colors(config):
     }
 
     if platform.system() == 'Windows':
-        c = dict(c.items() |
+        c = dict(list(c.items()) +
             [
             ('K', 8),
             ('R', 9),


### PR DESCRIPTION
unsupported operand type | list and list: python 2.7
